### PR TITLE
added VHOST_DOMAIN to parametarize ingress host name

### DIFF
--- a/common/scripts/update_manifest.sh
+++ b/common/scripts/update_manifest.sh
@@ -17,7 +17,7 @@ cp -ar k8s-manifests/* k8s-manifests/.git changed-k8s-manifests/
 
 cd changed-k8s-manifests/
 mkdir -p manifests/${APP_NAME}/
-helm template ../app/helm/ --set image.tag=${IMAGE_TAG} --set nameSuffix=${NAME_SUFFIX} --set userID=${USERID} > manifests/${APP_NAME}/manifest.yaml
+helm template ../app/helm/ --set image.tag=${IMAGE_TAG} --set nameSuffix=${NAME_SUFFIX} --set userID=${USERID} --set vhostDomain=${VHOST_DOMAIN} > manifests/${APP_NAME}/manifest.yaml
 git fetch
 git merge origin/master --ff-only
 git add .

--- a/showks-aggregator/production.yaml
+++ b/showks-aggregator/production.yaml
@@ -50,6 +50,7 @@ jobs:
       APP_NAME: showks-aggregator
       TAG_PREFIX: prod-
       BRANCH: master
+      VHOST_DOMAIN: .prod.showks.containerdays.jp
   - put: k8s-manifests
     params:
       repository: changed-k8s-manifests

--- a/showks-aggregator/staging.yaml
+++ b/showks-aggregator/staging.yaml
@@ -45,6 +45,7 @@ jobs:
       TAG_PREFIX: stg-
       BRANCH: staging
       NAME_SUFFIX: -temp
+      VHOST_DOMAIN: .stg.showks.containerdays.jp
   - put: k8s-manifests
     params:
       repository: changed-k8s-manifests

--- a/showks-canvas-USERNAME/production.yaml
+++ b/showks-canvas-USERNAME/production.yaml
@@ -51,6 +51,7 @@ jobs:
       TAG_PREFIX: prod-
       BRANCH: master
       USERID: USERNAME
+      VHOST_DOMAIN: .prod.showks.containerdays.jp
   - put: k8s-manifests
     params:
       repository: changed-k8s-manifests

--- a/showks-canvas-USERNAME/staging.yaml
+++ b/showks-canvas-USERNAME/staging.yaml
@@ -46,6 +46,7 @@ jobs:
       BRANCH: staging
       USERID: USERNAME
       NAME_SUFFIX: -temp
+      VHOST_DOMAIN: .stg.showks.containerdays.jp
   - put: k8s-manifests
     params:
       repository: changed-k8s-manifests

--- a/showks-portal-backend/production.yaml
+++ b/showks-portal-backend/production.yaml
@@ -50,6 +50,7 @@ jobs:
       APP_NAME: showks-portal-backend
       TAG_PREFIX: prod-
       BRANCH: master
+      VHOST_DOMAIN: .prod.showks.containerdays.jp
   - put: k8s-manifests
     params:
       repository: changed-k8s-manifests

--- a/showks-portal-backend/staging.yaml
+++ b/showks-portal-backend/staging.yaml
@@ -45,6 +45,7 @@ jobs:
       TAG_PREFIX: stg-
       BRANCH: staging
       NAME_SUFFIX: -temp
+      VHOST_DOMAIN: .stg.showks.containerdays.jp
   - put: k8s-manifests
     params:
       repository: changed-k8s-manifests

--- a/showks-portal-frontend/production.yaml
+++ b/showks-portal-frontend/production.yaml
@@ -50,6 +50,7 @@ jobs:
       APP_NAME: showks-portal-frontend
       TAG_PREFIX: prod-
       BRANCH: master
+      VHOST_DOMAIN: .prod.showks.containerdays.jp
   - put: k8s-manifests
     params:
       repository: changed-k8s-manifests

--- a/showks-portal-frontend/staging.yaml
+++ b/showks-portal-frontend/staging.yaml
@@ -45,6 +45,7 @@ jobs:
       TAG_PREFIX: stg-
       BRANCH: staging
       NAME_SUFFIX: -temp
+      VHOST_DOMAIN: .stg.showks.containerdays.jp
   - put: k8s-manifests
     params:
       repository: changed-k8s-manifests


### PR DESCRIPTION
I have added VHOST_DOMAIN parameter to put only one host rule in each app's ingress settings. The main purpose of the changes is to retrieve canvas URL by the aggregator properly.

Please push back if you have better idea or name of the variable.